### PR TITLE
毎回権限確認をしない

### DIFF
--- a/app/models/google_auth.php
+++ b/app/models/google_auth.php
@@ -22,6 +22,7 @@ class GoogleAuth extends AppModel
         $client->setClientSecret(GOOGLE_CLIENT_SECRET);
         $client->setRedirectUri(GOOGLE_REDIRECT_URI);
         $client->setDeveloperKey(GOOGLE_DEVELOPER_KEY);
+        $client->setApprovalPrompt('auto');
 
         return $client;
     }


### PR DESCRIPTION
ログイン時に毎回「このアプリが次の許可をリクエストしています」ダイアログが出るのですが、
初回に許可した後はスキップするようにしました。

googleのoauth画面にリダイレクトするURLの`approval_prompt`を`force`ではなく`auto`にするだけの変更です。
