### PR TITLE
use utf-8 charset for plain code

### DIFF
--- a/app/controllers/code_controller.php
+++ b/app/controllers/code_controller.php
@@ -60,7 +60,7 @@ class CodeController extends AppController
         $code = CodePack::get($user, $path)->getCode($code_id);
 
         $this->set(get_defined_vars());
-        header('Content-Type: text/plain');
+        header('Content-Type: text/plain; charset=utf-8');
     }
 
     /**


### PR DESCRIPTION
Just a small code :bow:
I also use this and its a great app :+1: 
but i noticed the plain code displays broken character :smile: 